### PR TITLE
feat(p2p): Implement periodic peer discovery and initialization, fixe…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,5 @@ coverage
 /cli/node_modules
 
 chain_data/*
+config.toml
+update.txt

--- a/util/src/generic.rs
+++ b/util/src/generic.rs
@@ -48,6 +48,10 @@ pub fn block_timestamp_to_naive_datetime(ts: BlockTimeStamp) -> NaiveDateTime {
 }
 
 pub async fn wb_list_check(from_address: &Address, to_address: &Address) -> Result<(), Error> {
+	let is_config_loaded = runtime_config::RuntimeDenyConfigCache::is_initialized().await;
+
+	println!("is_config_loaded: {}", is_config_loaded);
+
 	let config = runtime_config::RuntimeDenyConfigCache::get().await?;
 	let whitelisted_addresses = &config.whitelisted_addresses;
 	let blacklisted_addresses= &config.blacklisted_addresses;


### PR DESCRIPTION
feat(p2p): Implement periodic peer discovery and initialization, fixes #1
    
        - Add periodic peer discovery mechanism that runs every 60 seconds
        - Initialize peers after successful bootstrap and closest peer queries
        - Add new InitializePeers event type for peer refresh coordination
        - Move peer initialization logic from node health updates to dedicated flows
        - Add additional logging for peer ping results and initialization events
    
        This change improves peer discovery and connection management by:
        1. Actively discovering and refreshing peers on a regular interval
        2. Initializing peer connections after bootstrap and peer queries
        3. Removing redundant peer initialization from node health updates